### PR TITLE
bump to 1.6.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -129,11 +129,11 @@ atty = { version = "0.2",  optional = true }
 termcolor = { version = "1.1.1", optional = true }
 terminal_size = { version = "0.1.12", optional = true }
 lazy_static = { version = "1", optional = true }
-regex = { version = "1.5.5", optional = true }
+regex = { version = "1.6", optional = true }
 backtrace = { version = "0.3", optional = true }
 
 [dev-dependencies]
-regex = "1.5.5"
+regex = "1.6"
 lazy_static = "1"
 criterion = "0.3.2"
 trybuild = "1.0.18"


### PR DESCRIPTION
Because why the hell not?

1.6.0 (2022-07-05)
New features:
    FEATURE #832: Clarify that Captures::len includes all groups, not just matching groups.
    FEATURE #857: Add an ExactSizeIterator impl for SubCaptureMatches.
    FEATURE #861: Improve RegexSet documentation examples.
    FEATURE #877: Upgrade to Unicode 14.
Bug fixes:
    BUG #792: Fix error message rendering bug.

1.5.6 (2022-05-20)
    BUG #680: Fixes a bug where [[:alnum:][:^ascii:]] dropped [:alnum:] from the class.
    BUG #859: Fixes a bug where Hir::is_match_empty returned false for \b.
    BUG #862: Fixes a bug where 'ab??' matches 'ab' instead of 'a' in 'ab'.

<!--
Thanks for helping out!

Please link the appropriate issue from your PR.

If you don't have an issue, we'd recommend starting with one first so the PR can focus on the
implementation (unless its an obvious bug or documentation fix that will have
little conversation).
-->
